### PR TITLE
Go thread-safe in-memory cache with element time-to-live.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go thread-safe in-memory cache with element lifetime.
+# Go thread-safe in-memory cache with element time-to-live.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ go get -u github.com/EmirShimshir/inMemoryCache
 ```
 
 ## Description
-Go in-memory cache helps you store data of different types in a cache and access them by key.
+Go in-memory cache helps you store data of different types in a cache and access them by key. When adding a new element to the cache, specify the time after which the element will be unavailable.
 
 ```inMemoryCache.New()``` - constructor for new cache
 
-```Set(key string, value interface{}) error``` - write the __value__ to the cache by the __key__. The __key__ must not be empty.
+```Set(key string, value any, ttl time.Duration) error``` - write the __value__ to the cache by the __key__. The __key__ must not be empty. The __ttl__ is time to live for the new element, it must not be zero.
 
 ```Get(key string) (interface{}, error)``` - get the __value__ from the cache by the __key__. The __key__ must not be empty and the __value__ must exist.
 
@@ -24,37 +24,37 @@ package main
 
 import (
 	"fmt"
-	"log"
-
 	"github.com/EmirShimshir/inMemoryCache"
+	"log"
+	"time"
 )
 
 func main() {
 	cache := inMemoryCache.New()
 
-	err := cache.Set("1", 42)
-	if err != nil {
-		log.Println(err.Error())
-		return
+	err := cache.Set("userId", 42, 5 * time.Second)
+	if err != nil { // err == nil
+		log.Fatal(err)
 	}
 
-	value, err := cache.Get("1")
-	if err != nil {
-		log.Println(err.Error())
-		return
+	userId, err := cache.Get("userId")
+	if err != nil { // err == nil
+		log.Fatal(err)
 	}
+	fmt.Println(userId) // Output: 42
 
-	fmt.Printf("value: %v\n", value)
+	time.Sleep(6 * time.Second)
 
-	err = cache.Delete("1")
-	if err != nil {
-		log.Println(err.Error())
-		return
+	userId, err = cache.Get("userId")
+	if err != nil { // err != nil
+		log.Fatal(err) // <--
 	}
 }
 
 ```
 
 ```
-value: 42
+42
+2022/07/27 14:43:08 no value for the key userId
+exit status 1
 ```

--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/EmirShimshir/inMemoryCache"
 	"log"
 	"time"
+
+	"github.com/EmirShimshir/inMemoryCache"
 )
 
 func main() {
-	cache := inMemoryCache.New()
+	var cache inMemoryCache.Cache
+	cache = inMemoryCache.New()
 
 	err := cache.Set("userId", 42, 5 * time.Second)
 	if err != nil { // err == nil

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go in-memory cache
+# Go thread-safe in-memory cache with element lifetime.
 
 ## Installation
 
@@ -7,7 +7,7 @@ go get -u github.com/EmirShimshir/inMemoryCache
 ```
 
 ## Description
-Go in-memory cache helps you store data of different types in a cache and access them by key. When adding a new element to the cache, specify the time after which the element will be unavailable.
+Go in-memory cache is goroutine-safe, it helps you store data of different types in a cache and access them by key. When adding a new element to the cache, specify the time after which the element will be unavailable.
 
 ```inMemoryCache.New()``` - constructor for new cache
 

--- a/cache.go
+++ b/cache.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-type cache interface {
+type Cache interface {
 	Set(key string, value any, ttl time.Duration) error
 	Get(key string) (any, error)
 	Delete(key string) error
@@ -19,13 +19,12 @@ type cacheData struct {
 
 type cacheMem struct {
 	storage map[string]cacheData
-	mu      *sync.RWMutex
+	mu      sync.RWMutex
 }
 
-func New() *cacheMem {
+func New() Cache {
 	return &cacheMem{
 		storage: make(map[string]cacheData),
-		mu:      new(sync.RWMutex),
 	}
 }
 

--- a/cache.go
+++ b/cache.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-type CacheMethods interface {
+type cacheMethods interface {
 	Set(key string, value any, ttl time.Duration) error
 	Get(key string) (any, error)
 	Delete(key string) error
@@ -16,17 +16,17 @@ type data struct {
 	timeDelete time.Time
 }
 
-type Cache struct {
+type cache struct {
 	storage map[string]data
 }
 
-func New() *Cache {
-	return &Cache{
+func New() *cache {
+	return &cache{
 		storage: make(map[string]data),
 	}
 }
 
-func (c *Cache) Set(key string, value any, ttl time.Duration) error {
+func (c *cache) Set(key string, value any, ttl time.Duration) error {
 	if key == "" {
 		return fmt.Errorf("empty key")
 	}
@@ -40,7 +40,7 @@ func (c *Cache) Set(key string, value any, ttl time.Duration) error {
 	return nil
 }
 
-func (c *Cache) Get(key string) (any, error) {
+func (c *cache) Get(key string) (any, error) {
 	if key == "" {
 		return nil, fmt.Errorf("empty key")
 	}
@@ -60,7 +60,7 @@ func (c *Cache) Get(key string) (any, error) {
 	return data.value, nil
 }
 
-func (c *Cache) Delete(key string) error {
+func (c *cache) Delete(key string) error {
 	if key == "" {
 		return fmt.Errorf("empty key")
 	}

--- a/cache.go
+++ b/cache.go
@@ -61,7 +61,7 @@ func (c *cacheMem) Get(key string) (any, error) {
 	}
 
 	if time.Now().After(data.timeDelete) {
-		_ = c.Delete(key)
+		delete(c.storage, key)
 
 		return nil, fmt.Errorf("no value for the key %s", key)
 	}

--- a/cache.go
+++ b/cache.go
@@ -1,45 +1,63 @@
 package inMemoryCache
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type CacheMethods interface {
-	Set(key string, value interface{}) error
-	Get(key string) (interface{}, error)
+	Set(key string, value any, ttl time.Duration) error
+	Get(key string) (any, error)
 	Delete(key string) error
 }
 
+type data struct {
+	value      any
+	timeDelete time.Time
+}
+
 type Cache struct {
-	storage map[string]interface{}
+	storage map[string]data
 }
 
 func New() *Cache {
 	return &Cache{
-		storage: make(map[string]interface{}),
+		storage: make(map[string]data),
 	}
 }
 
-func (c *Cache) Set(key string, value interface{}) error {
+func (c *Cache) Set(key string, value any, ttl time.Duration) error {
 	if key == "" {
 		return fmt.Errorf("empty key")
 	}
 
-	c.storage[key] = value
+	if ttl == 0 {
+		return fmt.Errorf("time-to-live equals zero")
+	}
+
+	c.storage[key] = data{value: value, timeDelete: time.Now().Add(ttl)}
 
 	return nil
 }
 
-func (c *Cache) Get(key string) (interface{}, error) {
+func (c *Cache) Get(key string) (any, error) {
 	if key == "" {
 		return nil, fmt.Errorf("empty key")
 	}
 
-	value, exists := c.storage[key]
+	data, exists := c.storage[key]
 
 	if !exists {
 		return nil, fmt.Errorf("no value for the key %s", key)
 	}
 
-	return value, nil
+	if time.Now().After(data.timeDelete) {
+		_ = c.Delete(key)
+
+		return nil, fmt.Errorf("no value for the key %s", key)
+	}
+
+	return data.value, nil
 }
 
 func (c *Cache) Delete(key string) error {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/EmirShimshir/inMemoryCache
+module github.com/EmirShimshir/inMemoryCache/v2
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/EmirShimshir/inMemoryCache/v2
+module github.com/EmirShimshir/inMemoryCache
 
 go 1.18


### PR DESCRIPTION
Add time-to-live for elements of the cache.
Add sync.RWmutex to make cache thread-safety and avoid race condition.